### PR TITLE
Adds `revoked` query parameter to autocomplete

### DIFF
--- a/src/app/general-data.service.ts
+++ b/src/app/general-data.service.ts
@@ -142,15 +142,17 @@ export class GeneralDataService {
     return this._recordCounts[type] || 0;
   }
 
-  autocomplete(term, inactive: '' | boolean = false): Observable<Object> {
-    console.log('inactive', inactive);
+  autocomplete(term, inactive: '' | boolean = false, revoked: '' | boolean = false): Observable<Object> {
     if (term === '' || typeof term !== 'string') {
       return from([]);
     }
-    let params = new HttpParams().set('q', term).append('inactive', inactive.toString());
+    let params = new HttpParams().set('q', term)
+      .append('inactive', inactive.toString())
+      .append('revoked', revoked.toString());
+
     return this.loadFromApi('v3/search/autocomplete', params)
       .pipe(
-        map(({ results }: { results? }) => results || []),
+        map(({ results }: { results?}) => results || []),
         map(results => results.map(row => ({
           id: row.id,
           term: row.value


### PR DESCRIPTION
Fixes #7 

Resolves duplicate named results from displaying in autocomplete. Inactive credentials were filtered out but revoked credentials were not. This aligns with `v2` autocomplete functionality.